### PR TITLE
drop Scala 2.12 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
       fail-fast: false
       matrix:
         java: [8, 11, 17, 21]
-        scala: [2.12.x, 2.13.x, 3.x]
+        scala: [2.13.x, 3.x]
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4

--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ Lightbend Emoji is a wrapper around Java's Unicode handling.
 
 Supported Scala versions: 3, 2.13
 
+(The last version to support Scala 2.12 was [1.3.0](https://github.com/lightbend-labs/lightbend-emoji/releases/tag/1.3.0).)
+
 Add to `build.sbt`, inserting current version:
 
 ```

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Lightbend Emoji is a wrapper around Java's Unicode handling.
 
 ## Installation
 
-Supported Scala versions: 2.12, 2.13, 3
+Supported Scala versions: 3, 2.13
 
 Add to `build.sbt`, inserting current version:
 

--- a/build.sbt
+++ b/build.sbt
@@ -22,7 +22,7 @@ ThisBuild / versionScheme := Some("early-semver")
 
 /// build
 
-crossScalaVersions := Seq("2.13.16", "2.12.20", "3.3.4")
+crossScalaVersions := Seq("2.13.16", "3.3.4")
 scalaVersion := crossScalaVersions.value.head
 
 libraryDependencies ++= Seq(


### PR DESCRIPTION
wdyt @Philippus , finally time to leave 2.12 users in the lurch, without mission-critical emoji security patches?